### PR TITLE
docs: FreeBSDライセンス和訳のURL修正

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -8,7 +8,7 @@ FreeBSD ライセンスを採用しております。
 ライセンスはすべてのファイルの先頭に書かれています。
 また、下記のサイトにFreeBSDライセンスの和訳がありますので、参考になさってください。
 
-http://www.jp.FreeBSD.org/www.FreeBSD.org/ja/copyright/freebsd-license.html
+http://www.jp.FreeBSD.org/ja/copyright/freebsd-license.html
 
 ただし、ライセンスはあくまで英文のものと致します。和訳をライセンスとして採用しないのは
 また一つ新たなライセンスを作る事を避けるためです。

--- a/LICENSE
+++ b/LICENSE
@@ -8,7 +8,7 @@ FreeBSD ライセンスを採用しております。
 ライセンスはすべてのファイルの先頭に書かれています。
 また、下記のサイトにFreeBSDライセンスの和訳がありますので、参考になさってください。
 
-http://www.jp.FreeBSD.org/ja/copyright/freebsd-license.html
+https://www.freebsd.org/ja/copyright/freebsd-license/
 
 ただし、ライセンスはあくまで英文のものと致します。和訳をライセンスとして採用しないのは
 また一つ新たなライセンスを作る事を避けるためです。


### PR DESCRIPTION
`LICENSE` 記載のFreeBSDライセンス和訳のURLが誤っていたので修正します。